### PR TITLE
Support float values

### DIFF
--- a/addons/slidergamepad/hslider_gamepad.gd
+++ b/addons/slidergamepad/hslider_gamepad.gd
@@ -5,7 +5,7 @@ extends HSlider
 class_name HSliderGamepad
 
 @export var slider_speed: float = 2
-@export var dpad_step: int = 5
+@export var dpad_step: float = 5
 @export var joystick_discrete: bool = false
 # If set above 0, enables smooth discrete
 @export var joystick_smooth_discrete_threshold: float = 0.0
@@ -20,10 +20,9 @@ func _ready() -> void:
 	# Connect the event
 	gui_input.connect(_on_gui_input)
 
-func _process(delta: float) -> void:
+func _physics_process(_delta) -> void:
 	if sliding_dir == 0: return
-	
-	value += ceil(slider_speed * delta) * sliding_dir
+	value += slider_speed * sliding_dir
 
 func handle_joystick(event: InputEvent) -> void:
 	if not event is InputEventJoypadMotion: return

--- a/addons/slidergamepad/vslider_gamepad.gd
+++ b/addons/slidergamepad/vslider_gamepad.gd
@@ -5,7 +5,7 @@ extends VSlider
 class_name VSliderGamepad
 
 @export var slider_speed: float = 2
-@export var dpad_step: int = 5
+@export var dpad_step: float = 5
 @export var joystick_discrete: bool = false
 # If set above 0, enables smooth discrete
 @export var joystick_smooth_discrete_threshold: float = 0.0
@@ -20,10 +20,9 @@ func _ready() -> void:
 	# Connect the event
 	gui_input.connect(_on_gui_input)
 
-func _process(delta: float) -> void:
+func _physics_process(_delta) -> void:
 	if sliding_dir == 0: return
-	
-	value += ceil(slider_speed * delta) * sliding_dir
+	value += slider_speed * sliding_dir
 
 func handle_joystick(event: InputEvent) -> void:
 	if not event is InputEventJoypadMotion: return

--- a/demo/demo_scene.tscn
+++ b/demo/demo_scene.tscn
@@ -61,7 +61,11 @@ theme_override_constants/separation = 15
 [node name="SmoothSlider" type="HSlider" parent="VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
+max_value = 1.0
+step = 0.001
 script = ExtResource("3_7kb5c")
+slider_speed = 0.01
+dpad_step = 0.1
 
 [node name="SmoothValue" type="Label" parent="VBoxContainer/HBoxContainer"]
 custom_minimum_size = Vector2(50, 0)


### PR DESCRIPTION
Currently, sliders only work with integer values. This commit adds support for float values (e.g., a slider from 0 to 1 with 0.01 steps).

Also, we should use _physics_process instead of _process, since the latter doesn’t run at a constant frame rate (ref: https://docs.godotengine.org/en/stable/classes/class_node.html#class-node-private-method-physics-process)